### PR TITLE
Ensuring extension doesn't get accidentally pushed to npm.

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["caleuche-vscode"]
+  "ignore": []
 }

--- a/packages/caleuche-vscode/package.json
+++ b/packages/caleuche-vscode/package.json
@@ -1,5 +1,6 @@
 {
   "name": "caleuche-vscode",
+  "private": true,
   "publisher": "caleuche",
   "displayName": "caleuche-vscode",
   "description": "VS Code extension for Caleuche template files with syntax highlighting and sample preview.",


### PR DESCRIPTION
This pull request includes two changes related to the `caleuche-vscode` package configuration. The changes remove the package from the ignore list and mark it as private.

Configuration updates:

* [`.changeset/config.json`](diffhunk://#diff-ed5b41335ff968c5cfd8035d4b8f8c8c0538b6746182d522adb0312eb9137fc5L10-R10): Removed `caleuche-vscode` from the `ignore` list, allowing it to be included in dependency updates.
* [`packages/caleuche-vscode/package.json`](diffhunk://#diff-7b5ab0eaf0b90305fa1c8ffe9c9f305e3b509401d09a764521e97cb03bc5fc7cR3): Added the `"private": true` property to mark the `caleuche-vscode` package as private, preventing it from being published to a public registry.