### PR TITLE
Fixing release action.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22.x"
-          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/release.yaml` file. The change removes the `registry-url` configuration from the `actions/setup-node` step, simplifying the workflow configuration.