### PR TITLE
Adding java helper for environment variable.

### DIFF
--- a/.changeset/hungry-needles-roll.md
+++ b/.changeset/hungry-needles-roll.md
@@ -1,0 +1,6 @@
+---
+"@caleuche/core": minor
+---
+
+Adding java template helpers.
+Fixing consistency issue with csharp helper.

--- a/packages/caleuche/src/compile.ts
+++ b/packages/caleuche/src/compile.ts
@@ -3,6 +3,7 @@ import { CompileOptions, CompileOutput, Sample } from "./interfaces";
 import * as csharp from "./csharp";
 import * as go from "./go";
 import * as python from "./python";
+import * as java from "./java";
 
 function fillInputObject(
   sample: Sample,
@@ -127,6 +128,7 @@ export function compileSample(
       csharp: csharp,
       go: go,
       python: python,
+      java: java,
     },
   });
   const targetFileName = getTargetFileName(sample);

--- a/packages/caleuche/src/csharp.ts
+++ b/packages/caleuche/src/csharp.ts
@@ -14,7 +14,7 @@ export function valueOrEnvironment(
   value?: string,
 ): string {
   if (useEnvironmentVariable && environmentVariable) {
-    return `var ${variableName} = Environment.GetEnvironmentVariable("${environmentVariable}") ?? throw new InvalidOperationException("${environmentVariable} environment variable is not set.")`;
+    return `var ${variableName} = Environment.GetEnvironmentVariable("${environmentVariable}") ?? throw new InvalidOperationException("${environmentVariable} environment variable is not set.");`;
   } else if (value) {
     return `const string ${variableName} = "${value}";`;
   } else {

--- a/packages/caleuche/src/java.ts
+++ b/packages/caleuche/src/java.ts
@@ -1,0 +1,26 @@
+export function valueOrEnvironment(
+  useEnvironmentVariable: boolean,
+  variableName: string,
+  environmentVariable: string,
+  value?: string,
+  indentationLevel: number = 1,
+): string {
+  if (!variableName) {
+    throw new Error("Variable name must be provided.");
+  }
+  const indent = "    ".repeat(indentationLevel);
+
+  if (useEnvironmentVariable && environmentVariable) {
+    return (
+      `String ${variableName} = System.getenv("${environmentVariable}");\n` +
+      `${indent}if (${variableName} == null || ${variableName}.isEmpty()) {\n` +
+      `${indent}    System.out.println("Please set the ${environmentVariable} environment variable.");\n` +
+      `${indent}    System.exit(1);\n` +
+      `${indent}}`
+    );
+  } else if (value) {
+    return `String ${variableName} = "${value}";`;
+  } else {
+    throw new Error("No value provided for variable or environment variable.");
+  }
+}


### PR DESCRIPTION
This pull request introduces Java template helpers to the `@caleuche/core` package, improves consistency in the C# helper, and adds comprehensive tests for the new Java functionality. The most significant changes include adding Java support for environment variable handling, updating the compile logic to include Java, and fixing minor consistency issues in the C# helper.

### Java Template Support:

* Added a new `valueOrEnvironment` function in `packages/caleuche/src/java.ts` to handle environment variables and default values in Java templates. The function ensures proper indentation and includes error handling for missing environment variables.
* Updated `packages/caleuche/src/compile.ts` to include Java in the list of supported languages for compiling templates. [[1]](diffhunk://#diff-2157b6ce044cc3461b8e8e421aa9d0c3bdefc03589a28f934207b64da6264edbR6) [[2]](diffhunk://#diff-2157b6ce044cc3461b8e8e421aa9d0c3bdefc03589a28f934207b64da6264edbR131)

### Testing Enhancements:

* Added new test cases in `packages/caleuche/test/compileSample.test.ts` to validate Java templates with and without environment variable handling. These tests ensure the correctness of the generated Java code.

### C# Helper Consistency Fix:

* Fixed a minor formatting issue in the `valueOrEnvironment` function within `packages/caleuche/src/csharp.ts` by adding a semicolon at the end of the generated string for consistency.

### Documentation:

* Updated the `.changeset/hungry-needles-roll.md` file to document the addition of Java template helpers and the C# helper fix.