### PR TITLE
Fixing cli->core dependency.

### DIFF
--- a/packages/caleuche-cli/package.json
+++ b/packages/caleuche-cli/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "description": "Caleuche CLI",
   "dependencies": {
-    "@caleuche/core": "*",
+    "@caleuche/core": "workspace:^",
     "commander": "^14.0.0",
     "yaml": "^2.8.0"
   },


### PR DESCRIPTION
This pull request updates the dependency management for the `caleuche-cli` package. The most important change is transitioning the `@caleuche/core` dependency to use a workspace protocol version.

Dependency management:

* [`packages/caleuche-cli/package.json`](diffhunk://#diff-e99c956f471dcb624195eee480e68509864286a1448050eca37e2ed0ce8687b2L22-R22): Changed the version of the `@caleuche/core` dependency from a wildcard (`*`) to `workspace:^`, ensuring it aligns with the workspace versioning system for better compatibility and consistency.