### PR TITLE
Fixing dependency.

### DIFF
--- a/packages/caleuche-cli/package.json
+++ b/packages/caleuche-cli/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "description": "Caleuche CLI",
   "dependencies": {
-    "@caleuche/core": "workspace:^",
+    "@caleuche/core": "^0.1.2",
     "commander": "^14.0.0",
     "yaml": "^2.8.0"
   },


### PR DESCRIPTION
This pull request updates the dependency version for `@caleuche/core` in the `Caleuche CLI` project.

Dependency updates:

* [`packages/caleuche-cli/package.json`](diffhunk://#diff-e99c956f471dcb624195eee480e68509864286a1448050eca37e2ed0ce8687b2L22-R22): Changed the version of `@caleuche/core` from `workspace:^` to a specific version `^0.1.2` to ensure compatibility and stability.