### PR TITLE
Fixing issue with batch compilation.

### DIFF
--- a/.changeset/dirty-roses-lick.md
+++ b/.changeset/dirty-roses-lick.md
@@ -1,0 +1,5 @@
+---
+"@caleuche/cli": patch
+---
+
+Fixing issue with batch compilation.

--- a/packages/caleuche-cli/src/batch.ts
+++ b/packages/caleuche-cli/src/batch.ts
@@ -6,6 +6,7 @@ import {
   parse,
 } from "./utils";
 import { compileAndWriteOutput, resolveAndParseSample } from "./common";
+import path from "path";
 
 function loadVariantDefinition(
   variant: SampleVariantDefinition | SampleVariantPath,
@@ -86,7 +87,11 @@ export function batchCompile(batchFile: string) {
   }
   const samples = bachDefinition.samples;
   for (const sampleDefinition of samples) {
-    const sample = resolveAndParseSample(sampleDefinition.templatePath);
+    const templatePath = path.join(
+      path.dirname(batchFile),
+      sampleDefinition.templatePath,
+    );
+    const sample = resolveAndParseSample(templatePath);
     if (!sample) {
       process.exit(1);
     }
@@ -98,7 +103,7 @@ export function batchCompile(batchFile: string) {
       }
 
       if (
-        !compileAndWriteOutput(sample, resolvedVariant, variant.output, {
+        !compileAndWriteOutput(sample, resolvedVariant.data, variant.output, {
           project: true,
         })
       ) {

--- a/packages/caleuche-cli/src/index.ts
+++ b/packages/caleuche-cli/src/index.ts
@@ -2,6 +2,7 @@
 
 import { program } from "commander";
 import { compile } from "./compile";
+import { batchCompile } from "./batch";
 import { version } from "../package.json";
 
 program
@@ -14,8 +15,6 @@ program
   .option("-p, --project", "Generate project file")
   .action(compile);
 
-program.command("batch <batch-file>").action((batchFile) => {
-  console.log(`Batch compiling samples from ${batchFile}`);
-});
+program.command("batch <batch-file>").action(batchCompile);
 
 program.parse();


### PR DESCRIPTION
This pull request addresses a bug in batch compilation for the `@caleuche/cli` package and refactors the `batchCompile` command to improve functionality and maintainability. The key changes include fixing the handling of relative template paths in batch files, updating the `batchCompile` function to use the correct data structure, and integrating the `batchCompile` command into the CLI.

### Bug Fixes:

* [`.changeset/dirty-roses-lick.md`](diffhunk://#diff-fb085874cccca860413b81f3ec74b0af7e26e8fc8c1ca19642901a7787b630bfR1-R5): Added a patch changelog entry for fixing the issue with batch compilation.
* [`packages/caleuche-cli/src/batch.ts`](diffhunk://#diff-b8c2c842fe816ba33f6bf440bfe8d0d6bcadd78486c062f13f696b4c88301450L89-R94): Corrected the handling of relative paths for `templatePath` in batch files by using `path.join` with the directory of the batch file.

### Refactoring and CLI Improvements:

* [`packages/caleuche-cli/src/batch.ts`](diffhunk://#diff-b8c2c842fe816ba33f6bf440bfe8d0d6bcadd78486c062f13f696b4c88301450L101-R106): Updated the `batchCompile` function to pass `resolvedVariant.data` instead of `resolvedVariant` when calling `compileAndWriteOutput`, ensuring the correct data structure is used.
* [`packages/caleuche-cli/src/index.ts`](diffhunk://#diff-4ebaef4e2dbee42a58709963d710b8c2cbc1d9c84c2bda7137d7caaf017a9b31L17-R18): Integrated the `batchCompile` function into the CLI by replacing the placeholder `batch` command implementation with a direct call to `batchCompile`.
* [`packages/caleuche-cli/src/index.ts`](diffhunk://#diff-4ebaef4e2dbee42a58709963d710b8c2cbc1d9c84c2bda7137d7caaf017a9b31R5): Imported the `batchCompile` function into the CLI entry point.