### PR TITLE
Making batch output path relative. Fixing variant references.

### DIFF
--- a/.changeset/loose-baths-film.md
+++ b/.changeset/loose-baths-film.md
@@ -1,0 +1,5 @@
+---
+"@caleuche/cli": patch
+---
+
+Making batch output path relative. Fixing variant references.


### PR DESCRIPTION
This pull request introduces updates to the `@caleuche/cli` package to improve batch processing functionality. The most notable changes include making the batch output path relative, fixing variant references, and enhancing logging for better debugging. Additionally, the `resolveVariantDefinition` function has been updated to handle nested `data` properties in variant configurations.

### Batch processing improvements:

* **Relative output paths**: Updated the `batchCompile` function to compute the `effectiveOutputPath` by joining the batch file directory with the variant's output path, ensuring paths are relative. (`packages/caleuche-cli/src/batch.ts`, [packages/caleuche-cli/src/batch.tsR106-R118](diffhunk://#diff-b8c2c842fe816ba33f6bf440bfe8d0d6bcadd78486c062f13f696b4c88301450R106-R118))

* **Enhanced logging**: Added console logs to provide better visibility during batch processing, including the number of loaded variant definitions and details about the samples and variants being processed. (`packages/caleuche-cli/src/batch.ts`, [[1]](diffhunk://#diff-b8c2c842fe816ba33f6bf440bfe8d0d6bcadd78486c062f13f696b4c88301450R87-R95) [[2]](diffhunk://#diff-b8c2c842fe816ba33f6bf440bfe8d0d6bcadd78486c062f13f696b4c88301450R106-R118)

### Variant reference handling:

* **Fixed variant references**: Modified the `resolveVariantDefinition` function to work with nested `data` properties in `SampleVariantConfig`, ensuring proper resolution of paths, definitions, and references. (`packages/caleuche-cli/src/batch.ts`, [packages/caleuche-cli/src/batch.tsL46-R63](diffhunk://#diff-b8c2c842fe816ba33f6bf440bfe8d0d6bcadd78486c062f13f696b4c88301450L46-R63))

### Metadata update:

* **Changeset added**: Documented the changes as a patch update for the `@caleuche/cli` package. (`.changeset/loose-baths-film.md`, [.changeset/loose-baths-film.mdR1-R5](diffhunk://#diff-e03fcd640932d0d03e86e01fe6f4ae25011d533ca9793a5535e8469af0a8a2beR1-R5))