### PR TITLE
New schema for batch files.

### DIFF
--- a/.changeset/deep-bananas-unite.md
+++ b/.changeset/deep-bananas-unite.md
@@ -1,0 +1,5 @@
+---
+"@caleuche/cli": minor
+---
+
+Changing batch file schema.

--- a/docs/batch.md
+++ b/docs/batch.md
@@ -1,0 +1,65 @@
+### Batch Template Compilation
+
+The `batch` command allows you to compile multiple template samples in a single operation, using a configuration file to specify the inputs and outputs.
+
+#### Batch File Schema
+
+The batch input file is a YAML or JSON document with the following structure:
+
+```yaml
+variants:                # (optional) List of named input variants
+  - name: string         # Name of the variant
+    input:               # Input definition (object or path)
+      type: object       # or "path"
+      properties:        # (if type: object) Key-value pairs for template variables
+      # or
+      type: path
+      value: path/to/input.yaml
+
+samples:                 # List of samples to compile
+  - templatePath: path/to/template
+    variants:            # List of output variants for this sample
+      - output: path/to/output
+        input:           # Input for this variant (object, path, or reference)
+          type: object   # or "path" or "reference"
+          properties:    # (if type: object)
+          # or
+          type: path
+          value: path/to/input.yaml
+          # or
+          type: reference
+          value: variantName
+        # Shorthand: if input is a string, it is treated as a reference
+        # Example:
+        # input: dev
+```
+
+#### Input Types
+
+- **object**: Inline key-value pairs for template variables.
+- **path**: Reference to an external YAML file with input data.
+- **reference**: Refers to a named variant defined in the `variants` section (note that just using input as a string it is equivalent to this)
+
+#### Example
+
+```yaml
+variants:
+  - name: dev
+    input:
+      type: object
+      properties:
+        ENV: development
+        DEBUG: true
+
+samples:
+  - templatePath: ./project-templates/Sample.csproj.template
+    variants:
+      - output: ./out/Sample.csproj
+        input: dev           # Shorthand for reference
+      - output: ./out/Sample.Release.csproj
+        input:
+          type: object
+          properties:
+            ENV: production
+            DEBUG: false
+```

--- a/docs/batch.md
+++ b/docs/batch.md
@@ -52,11 +52,11 @@ variants:
         DEBUG: true
 
 samples:
-  - templatePath: ./project-templates/Sample.csproj.template
+  - templatePath: ./project-templates/Sample.cs.template
     variants:
-      - output: ./out/Sample.csproj
+      - output: ./out-dev/
         input: dev           # Shorthand for reference
-      - output: ./out/Sample.Release.csproj
+      - output: ./out-prod/
         input:
           type: object
           properties:

--- a/packages/caleuche-cli/src/batch.ts
+++ b/packages/caleuche-cli/src/batch.ts
@@ -1,72 +1,85 @@
-import fs from "fs";
 import {
   getAbsoluteDirectoryPath,
+  getVariantInputReferenceValue,
   isFile,
-  isVariantDefinition,
+  isVariantInputDefinition,
+  isVariantInputReference,
   parse,
 } from "./utils";
 import { compileAndWriteOutput, resolveAndParseSample } from "./common";
 import path from "path";
 
-function loadVariantDefinition(
-  variant: SampleVariantDefinition | SampleVariantPath,
-  workingDirectory: string
-): SampleVariantDefinition | null {
-  if (isVariantDefinition(variant)) {
-    return variant;
-  } else if (fs.existsSync(path.join(workingDirectory, variant))) {
-    const v = parse<SampleVariantDefinition>(path.join(workingDirectory, variant));
-    if (!v) {
-      console.error(`Failed to parse variant at path: ${variant}`);
-      return null;
-    }
-    return v;
-  }
-  return null;
-}
-
-function loadVariantDefinitions(
-  variants: Record<string, SampleVariantDefinition | SampleVariantPath> | undefined,
-  workingDirectory: string
-): Record<string, SampleVariantDefinition> | null {
-  if (!variants) return {};
-  const definitions: Record<string, SampleVariantDefinition> = {};
-  for (const [key, variant] of Object.entries(variants)) {
-    const v = loadVariantDefinition(variant, workingDirectory);
-    if (!v) {
+function loadVariantInputDefinition(
+  variantInput: SampleVariantInputDefinition | SampleVariantInputPath,
+  workingDirectory: string,
+): SampleVariantInputDefinition | null {
+  if (isVariantInputDefinition(variantInput)) {
+    return variantInput;
+  } else {
+    const absolutePath = path.join(workingDirectory, variantInput.value);
+    if (isFile(absolutePath)) {
+      const v = parse<SampleVariantInputDefinition>(absolutePath);
+      if (!v) {
+        console.error(`Failed to parse variant at path: ${absolutePath}`);
+        return null;
+      }
+      return v;
+    } else {
       console.error(
-        `Failed to load variant definition for key "${key}": ${variant}`,
+        `Variant input path "${variantInput.value}" does not exist or is not a file.`,
       );
       return null;
     }
-    definitions[key] = v;
+  }
+}
+
+function loadVariantDefinitions(
+  variants: SampleVariantInputEntry[] | undefined,
+  workingDirectory: string,
+): Record<string, SampleVariantInputDefinition> | null {
+  if (!variants) return {};
+  const definitions: Record<string, SampleVariantInputDefinition> = {};
+  for (const { name, input } of variants) {
+    const v = loadVariantInputDefinition(input, workingDirectory);
+    if (!v) {
+      console.error(
+        `Failed to load variant definition for key "${name}": ${input}`,
+      );
+      return null;
+    }
+    definitions[name] = v;
   }
   return definitions;
 }
 
 function resolveVariantDefinition(
   variant: SampleVariantConfig,
-  variantRegistry: Record<string, SampleVariantDefinition>,
-  workingDirectory: string
-): SampleVariantDefinition | null {
-  if (isVariantDefinition(variant.data)) {
-    return variant.data;
-  }
-
-  if (isFile(path.join(workingDirectory, variant.data))) {
-    const v = parse<SampleVariantDefinition>(path.join(workingDirectory, variant.data));
+  variantRegistry: Record<string, SampleVariantInputDefinition>,
+  workingDirectory: string,
+): SampleVariantInputDefinition | null {
+  if (isVariantInputReference(variant.input)) {
+    const ref = getVariantInputReferenceValue(variant.input);
+    const v = variantRegistry[ref];
     if (v) {
       return v;
     }
-  }
-
-
-    const v = variantRegistry[variant.data];
-    if (v) {
-      return v;
+    console.error(`Variant "${ref}" could not be resolved.`);
+    return null;
+  } else if (isVariantInputDefinition(variant.input)) {
+    return variant.input;
+  } else {
+    const absolutePath = path.join(workingDirectory, variant.input.value);
+    if (isFile(absolutePath)) {
+      const v = parse<SampleVariantInputDefinition>(absolutePath);
+      if (v) {
+        return v;
+      }
     }
-    console.error(`Variant "${variant.data}" could not be resolved.`);
-    return null
+    console.error(
+      `Variant input path "${variant.input.value}" does not exist or is not a file.`,
+    );
+    return null;
+  }
 }
 
 export function batchCompile(batchFile: string) {
@@ -76,19 +89,22 @@ export function batchCompile(batchFile: string) {
   }
   const workingDirectory = getAbsoluteDirectoryPath(batchFile);
   console.log(`Working directory: ${workingDirectory}`);
-  const bachDefinition = parse<BatchCompileOptions>(batchFile);
-  if (!bachDefinition) {
+  const batchDefinition = parse<BatchCompileDescription>(batchFile);
+  if (!batchDefinition) {
     console.error(`Failed to parse batch file: ${batchFile}`);
     process.exit(1);
   }
-  const variants = loadVariantDefinitions(bachDefinition.variants, workingDirectory);
+  const variants = loadVariantDefinitions(
+    batchDefinition.variants,
+    workingDirectory,
+  );
   console.log(
     `Loaded ${Object.keys(variants || {}).length} variant definitions from batch file.`,
   );
   if (!variants) {
     process.exit(1);
   }
-  const samples = bachDefinition.samples;
+  const samples = batchDefinition.samples;
   for (const sampleDefinition of samples) {
     console.log(`Processing sample: ${sampleDefinition.templatePath}`);
     const templatePath = path.join(
@@ -102,15 +118,16 @@ export function batchCompile(batchFile: string) {
 
     for (const variant of sampleDefinition.variants) {
       console.log("Processing variant...");
-      const resolvedVariant = resolveVariantDefinition(variant, variants, workingDirectory);
+      const resolvedVariant = resolveVariantDefinition(
+        variant,
+        variants,
+        workingDirectory,
+      );
       if (!resolvedVariant) {
         process.exit(1);
       }
 
-      const effectiveOutputPath = path.join(
-        workingDirectory,
-        variant.output,
-      );
+      const effectiveOutputPath = path.join(workingDirectory, variant.output);
 
       if (
         !compileAndWriteOutput(sample, resolvedVariant, effectiveOutputPath, {

--- a/packages/caleuche-cli/src/interfaces.ts
+++ b/packages/caleuche-cli/src/interfaces.ts
@@ -1,14 +1,26 @@
-type SampleVariantDefinition = Record<string, any>;
-type SampleVariantReference = string;
-type SampleVariantPath = string;
-type SampleVariant =
-  | SampleVariantDefinition
-  | SampleVariantReference
-  | SampleVariantPath;
+interface SampleVariantInputDefinition {
+  type: "object";
+  properties: Record<string, any>;
+}
+
+interface SampleVariantInputReference {
+  type: "reference";
+  value: string;
+}
+
+interface SampleVariantInputPath {
+  type: "path";
+  value: string;
+}
+
+type SampleVariantInput =
+  | SampleVariantInputDefinition
+  | SampleVariantInputReference
+  | SampleVariantInputPath;
 
 interface SampleVariantConfig {
   output: string;
-  data: SampleVariant;
+  input: SampleVariantInput | string;
 }
 
 interface SampleDefinition {
@@ -16,7 +28,12 @@ interface SampleDefinition {
   variants: SampleVariantConfig[];
 }
 
-interface BatchCompileOptions {
-  variants?: Record<string, SampleVariantDefinition | SampleVariantPath>;
+interface SampleVariantInputEntry {
+  name: string;
+  input: SampleVariantInputDefinition | SampleVariantInputPath;
+}
+
+interface BatchCompileDescription {
+  variants?: SampleVariantInputEntry[];
   samples: SampleDefinition[];
 }

--- a/packages/caleuche-cli/src/utils.ts
+++ b/packages/caleuche-cli/src/utils.ts
@@ -52,15 +52,37 @@ export function isObject(value: any): value is Record<string, any> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-export function isVariantDefinition(
-  variant: SampleVariant,
-): variant is SampleVariantDefinition {
-  return isObject(variant) && !Array.isArray(variant);
+export function isVariantInputDefinition(
+  variant: SampleVariantInput,
+): variant is SampleVariantInputDefinition {
+  return isObject(variant) && variant.type === "object";
 }
 
-export function getAbsoluteDirectoryPath(
-  filePath: string,
+export function isVariantInputPath(
+  variant: SampleVariantInput,
+): variant is SampleVariantInputPath {
+  return isObject(variant) && variant.type === "path";
+}
+
+export function isVariantInputReference(
+  variant: SampleVariantInput | string,
+): variant is SampleVariantInputReference | string {
+  return (
+    (isObject(variant) && variant.type === "reference") ||
+    typeof variant === "string"
+  );
+}
+
+export function getVariantInputReferenceValue(
+  variant: SampleVariantInputReference | string,
 ): string {
+  if (typeof variant === "string") {
+    return variant;
+  }
+  return variant.value;
+}
+
+export function getAbsoluteDirectoryPath(filePath: string): string {
   return path.dirname(path.resolve(filePath));
 }
 

--- a/packages/caleuche-cli/test/common.test.ts
+++ b/packages/caleuche-cli/test/common.test.ts
@@ -6,11 +6,7 @@ import fs from "fs";
 const mockFs = vi.mocked(fs);
 
 vi.mock("../src/utils");
-import {
-  parse,
-  resolveSampleFile,
-  isFile,
-} from "../src/utils";
+import { parse, resolveSampleFile, isFile } from "../src/utils";
 import { resolveAndParseSample } from "../src/common";
 const mockParse = vi.mocked(parse);
 const mockResolveSampleFile = vi.mocked(resolveSampleFile);


### PR DESCRIPTION
This pull request introduces a significant refactor and enhancement of the batch compilation feature, focusing on improving the handling of input variants and streamlining the codebase. Key changes include the introduction of a new schema for batch input files, updates to variant input handling, and corresponding updates to the tests.

### Documentation Updates:
* Added a detailed section in `docs/batch.md` explaining the new batch template compilation feature, including the YAML/JSON schema, input types, and an example.

### Code Enhancements:
* Refactored the `batch.ts` file to replace the old variant handling logic with a new system based on `SampleVariantInput` types (`object`, `path`, `reference`). This includes renaming functions, updating error messages, and improving the resolution logic for variant inputs. [[1]](diffhunk://#diff-b8c2c842fe816ba33f6bf440bfe8d0d6bcadd78486c062f13f696b4c88301450L1-R82) [[2]](diffhunk://#diff-b8c2c842fe816ba33f6bf440bfe8d0d6bcadd78486c062f13f696b4c88301450L79-R107) [[3]](diffhunk://#diff-b8c2c842fe816ba33f6bf440bfe8d0d6bcadd78486c062f13f696b4c88301450L105-R130)

### Type Definitions:
* Updated `interfaces.ts` to introduce new interfaces (`SampleVariantInputDefinition`, `SampleVariantInputReference`, `SampleVariantInputPath`) and a unified `SampleVariantInput` type, replacing the older `SampleVariant` and related types.

### Utility Functions:
* Added new utility functions (`isVariantInputDefinition`, `isVariantInputPath`, `isVariantInputReference`, `getVariantInputReferenceValue`) in `utils.ts` to support the updated variant input logic. Removed the old `isVariantDefinition` function.

### Test Updates:
* Refactored `bach.test.ts` to align with the new batch compilation logic. This includes updating mock data, replacing deprecated type checks, and ensuring compatibility with the new schema and utility functions. [[1]](diffhunk://#diff-3f7084fcaede22f83c75592d2bacb618e1575c20aaad79f606b0cc2fd86b6497L18-R32) [[2]](diffhunk://#diff-3f7084fcaede22f83c75592d2bacb618e1575c20aaad79f606b0cc2fd86b6497L89-R97) [[3]](diffhunk://#diff-3f7084fcaede22f83c75592d2bacb618e1575c20aaad79f606b0cc2fd86b6497L242-R261)