### PR TITLE
Updated command help strings.

### DIFF
--- a/.changeset/soft-eyes-attack.md
+++ b/.changeset/soft-eyes-attack.md
@@ -1,0 +1,5 @@
+---
+"@caleuche/cli": minor
+---
+
+Updated command help strings.

--- a/packages/caleuche-cli/src/index.ts
+++ b/packages/caleuche-cli/src/index.ts
@@ -11,10 +11,17 @@ program
   .version(version);
 
 program
-  .command("compile <sample-directory> <data-file> <output-directory>")
-  .option("-p, --project", "Generate project file")
+  .command("compile")
+  .argument("<sample-path>", "Path to the sample file or the directory that containes it.")
+  .argument("<data-file>", "Path to the input to be used to compile the template.")
+  .argument("<output-directory>", "Directory where the compiled output will be written.")
+  .option("-p, --project", "Flag to indicate whether to generate the appropriate project file along with the compiled template.")
   .action(compile);
 
-program.command("batch <batch-file>").action(batchCompile);
+program
+  .command("batch")
+  .argument("<batch-file>", "Path to the batch file")
+  .option("-d, --output-dir", "Output directory for compiled samples")
+  .action(batchCompile);
 
 program.parse();


### PR DESCRIPTION
This pull request makes improvements to the CLI of the `@caleuche/cli` package by updating command help strings and improving the clarity and flexibility of argument and option definitions for the `compile` and `batch` commands.

### CLI Improvements:

* Updated the `compile` command to use `.argument()` for clearer descriptions of required inputs (`<sample-path>`, `<data-file>`, `<output-directory>`) and enhanced the description of the `--project` option. (`packages/caleuche-cli/src/index.ts`, [packages/caleuche-cli/src/index.tsL14-R25](diffhunk://#diff-4ebaef4e2dbee42a58709963d710b8c2cbc1d9c84c2bda7137d7caaf017a9b31L14-R25))
* Updated the `batch` command to include an optional `--output-dir` flag for specifying the output directory, along with a clearer description for the `<batch-file>` argument. (`packages/caleuche-cli/src/index.ts`, [packages/caleuche-cli/src/index.tsL14-R25](diffhunk://#diff-4ebaef4e2dbee42a58709963d710b8c2cbc1d9c84c2bda7137d7caaf017a9b31L14-R25))
* Added a changeset file to indicate a minor version bump for `@caleuche/cli` due to these updates. (`.changeset/soft-eyes-attack.md`, [.changeset/soft-eyes-attack.mdR1-R5](diffhunk://#diff-ac41ebf832c503b72a912a20d26b56a4e457441ee670d68e6df6043f9c30a844R1-R5))