### PR TITLE
Adding output directory option to batch command.

### DIFF
--- a/.changeset/tender-pandas-live.md
+++ b/.changeset/tender-pandas-live.md
@@ -1,0 +1,5 @@
+---
+"@caleuche/cli": minor
+---
+
+Adding option directory to batch command.

--- a/packages/caleuche-cli/src/batch.ts
+++ b/packages/caleuche-cli/src/batch.ts
@@ -80,7 +80,7 @@ function resolveVariantDefinition(
   }
 }
 
-export function batchCompile(batchFile: string) {
+export function batchCompile(batchFile: string, options: { outputDir?: string }) {
   if (!isFile(batchFile)) {
     console.error(`Batch file "${batchFile}" does not exist or is not a file.`);
     process.exit(1);
@@ -125,10 +125,12 @@ export function batchCompile(batchFile: string) {
         process.exit(1);
       }
 
-      const effectiveOutputPath = path.join(workingDirectory, variant.output);
+      const effectiveOutputPath = path.join(
+        options.outputDir || workingDirectory,
+        variant.output);
 
       if (
-        !compileAndWriteOutput(sample, resolvedVariant, effectiveOutputPath, {
+        !compileAndWriteOutput(sample, resolvedVariant.properties, effectiveOutputPath, {
           project: true,
         })
       ) {

--- a/packages/caleuche-cli/src/batch.ts
+++ b/packages/caleuche-cli/src/batch.ts
@@ -126,7 +126,7 @@ export function batchCompile(batchFile: string, options: { outputDir?: string })
       }
 
       const effectiveOutputPath = path.join(
-        options.outputDir || workingDirectory,
+        options?.outputDir || workingDirectory,
         variant.output);
 
       if (

--- a/packages/caleuche-cli/src/index.ts
+++ b/packages/caleuche-cli/src/index.ts
@@ -21,7 +21,7 @@ program
 program
   .command("batch")
   .argument("<batch-file>", "Path to the batch file")
-  .option("-d, --output-dir", "Output directory for compiled samples")
+  .option("-d, --output-dir <outputDir>", "Output directory for compiled samples")
   .action(batchCompile);
 
 program.parse();


### PR DESCRIPTION
This pull request introduces enhancements to the `batchCompile` function in the `caleuche-cli` package, adding support for specifying an output directory via a new `options` parameter. It also includes a fix to improve how variant properties are handled during compilation. Additionally, the CLI command definition is updated to reflect these changes.

### Enhancements to `batchCompile` functionality:
* [`packages/caleuche-cli/src/batch.ts`](diffhunk://#diff-b8c2c842fe816ba33f6bf440bfe8d0d6bcadd78486c062f13f696b4c88301450L83-R83): Updated the `batchCompile` function to accept an `options` parameter, allowing users to specify an optional `outputDir` for compiled samples. The effective output path now uses `options.outputDir` if provided, falling back to the working directory otherwise. [[1]](diffhunk://#diff-b8c2c842fe816ba33f6bf440bfe8d0d6bcadd78486c062f13f696b4c88301450L83-R83) [[2]](diffhunk://#diff-b8c2c842fe816ba33f6bf440bfe8d0d6bcadd78486c062f13f696b4c88301450L128-R133)

### CLI improvements:
* [`packages/caleuche-cli/src/index.ts`](diffhunk://#diff-4ebaef4e2dbee42a58709963d710b8c2cbc1d9c84c2bda7137d7caaf017a9b31L24-R24): Modified the `batch` command definition to require a value for the `--output-dir` option (e.g., `--output-dir <outputDir>`), ensuring users explicitly specify the output directory when using this option.