### PR TITLE
[WIP] Adding gradle support for sample generation

### DIFF
--- a/packages/caleuche-cli/README.md
+++ b/packages/caleuche-cli/README.md
@@ -18,6 +18,20 @@ che compile <sample-directory|sample-file> <data-file> <output-directory> [optio
 - `<data-file>`: Path to the data file (JSON or YAML).
 - `<output-directory>`: Directory where the generated project will be placed.
 
+## running locally
+
+From the dev container, run 
+
+```bash
+yarn
+```
+
+And then:
+
+```bash
+npx che .... # your inputs
+```
+
 ### Options
 
 - `-p, --project` Generate project file (e.g., csproj, go.mod, etc.)

--- a/packages/caleuche/project-templates/build.gradle.template
+++ b/packages/caleuche/project-templates/build.gradle.template
@@ -1,0 +1,26 @@
+plugins {
+    id 'java'
+}
+
+group = 'sample'
+version = '1.0-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+<% _.forEach(dependencies, function(dependency) { %>
+    implementation '<%= dependency.name %>:<%= dependency.version %>'
+<% }); %>
+}
+
+/* keep the generated Sample.java visible to Gradle,
+   mirroring build-helper-maven-plugin in the POM */
+sourceSets {
+    main {
+        java {
+            srcDir '.'
+        }
+    }
+}

--- a/packages/caleuche/src/compile.ts
+++ b/packages/caleuche/src/compile.ts
@@ -33,6 +33,7 @@ function preprocessTemplate(template: string): string {
   return template.replace(regex, "$1");
 }
 
+import buildGradle from "../project-templates/build.gradle.template";
 import csproj from "../project-templates/Sample.csproj.template";
 import gomod from "../project-templates/go.mod.template";
 import packageJson from "../project-templates/package.json.template";
@@ -61,10 +62,17 @@ function getProjectFileTemplate(sample: Sample): {
         template: preprocessTemplate(packageJson),
       };
     case "java":
-      return {
-        targetFileName: `pom.xml`,
-        template: preprocessTemplate(pomXml),
-      };
+      if (sample.buildSystem === "gradle") {
+        return {
+          targetFileName: `build.gradle`,
+          template: preprocessTemplate(buildGradle),
+        };
+      } else {
+        return {
+          targetFileName: `pom.xml`,
+          template: preprocessTemplate(pomXml),
+        };
+      }
     case "python":
       return {
         targetFileName: `requirements.txt`,

--- a/packages/caleuche/src/interfaces.ts
+++ b/packages/caleuche/src/interfaces.ts
@@ -41,6 +41,7 @@ export type TemplateInput =
 export interface Sample {
   template: string;
   type: Language;
+  buildSystem?: string;
   dependencies: Dependency[];
   input: TemplateInput[];
 }


### PR DESCRIPTION
This is still a **WIP**

- Currently `project-templates` contains the necessary files for each language to setup a project. 
- `gradle` unlike other build systems needs **multiple files** to run. In addition to `build.gradle` the necessary files are: 
  - `settings.gradle`: defines structure of the project. [doc.(https://docs.gradle.org/current/userguide/settings_file_basics.html)
  - `gradlew`: wrapper for Unix/macOS systems (need to `chmod +x` it)
  - `gradlew.bat`: wrapper script for Windows
  - `gradle/wrapper/gradle-wrapper.jar`: the actual Gradle wrapper app.
  - `gradle/wrapper/gradle-wrapper.properties`: pinned distrubution

Technically, only `build.gradle` and `settings.gradle` are strictly necessary, but then we burden the consumer of the sample to have gradle installed locally and generate the [Gradle wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html) locally (I think this is a no-go)

So to summarize: I am blocked on being able to ship multiple files per project template. Also, we should probably add a script that generates Gradle wrapper on a sample validation step or something like that.
